### PR TITLE
Change multiple separator to ;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## BREAKING CHANGES
 
+* Change default `multiple_sep` to `;` (PR #25). This aligns with an upcoming breaking change in
+  Viash 0.9.0 in order to avoid issues with the current default separator `:` unintentionally
+  splitting up certain file paths.
+
 ## NEW FEATURES
 
 * `arriba`: Detect gene fusions from RNA-seq data (PR #1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 
 * Uniformize component metadata (PR #23).
 
+* Update to Viash 0.8.5 (PR #25).
+
 ## DOCUMENTATION
 
 ## BUG FIXES

--- a/_viash.yaml
+++ b/_viash.yaml
@@ -1,1 +1,5 @@
 viash_version: 0.8.4
+
+config_mods: |
+  .functionality.arguments[.multiple == true].multiple_sep := ";"
+  .functionality.argument_groups[true].arguments[.multiple == true].multiple_sep := ";"

--- a/_viash.yaml
+++ b/_viash.yaml
@@ -1,4 +1,4 @@
-viash_version: 0.8.4
+viash_version: 0.8.5
 
 config_mods: |
   .functionality.arguments[.multiple == true].multiple_sep := ";"

--- a/src/arriba/config.vsh.yaml
+++ b/src/arriba/config.vsh.yaml
@@ -134,29 +134,27 @@ functionality:
           type: string
           description: |
             List of interesting contigs. Fusions between genes 
-            on other contigs are ignored. Cfontigs can be specified with or without the 
+            on other contigs are ignored. Contigs can be specified with or without the 
             prefix "chr". Asterisks (*) are treated as wild-cards. 
             Default: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 X Y AC_* NC_*
           required: false
           multiple: true
-          multiple_sep: ","
           example: ["1", "2", "AC_*", "NC_*"]
         - name: --viral_contigs
           alternatives: -v
           type: string
           description: |
-            Comma-/space-separated list of viral contigs. Asterisks (*) are treated as 
+            List of viral contigs. Asterisks (*) are treated as 
             wild-cards.
             Default: AC_* NC_*
           required: false
           multiple: true
-          multiple_sep: ","
           example: ["AC_*", "NC_*"]
         - name: --disable_filters
           alternatives: -f
           type: string
           description: |
-            Comma-/space-separated list of filters to disable. By default all filters are 
+            List of filters to disable. By default all filters are 
             enabled. 
           choices: [ homologs, low_entropy, isoforms, 
             top_expressed_viral_contigs, viral_contigs, uninteresting_contigs, 
@@ -170,7 +168,6 @@ functionality:
             homopolymer, many_spliced ]
           required: false
           multiple: true
-          multiple_sep: ","
         - name: --max_e_value
           alternatives: -E
           type: double

--- a/src/arriba/script.sh
+++ b/src/arriba/script.sh
@@ -3,10 +3,17 @@
 ## VIASH START
 ## VIASH END
 
+# unset flags
 [[ "$par_skip_duplicate_marking" == "false" ]] && unset par_skip_duplicate_marking
 [[ "$par_extra_information" == "false" ]] && unset par_extra_information
 [[ "$par_fill_gaps" == "false" ]] && unset par_fill_gaps
 
+# replace ';' with ','
+par_interesting_contigs=$(echo $par_interesting_contigs | tr ';' ',')
+par_viral_contigs=$(echo $par_viral_contigs | tr ';' ',')
+par_disable_filters=$(echo $par_disable_filters | tr ';' ',')
+
+# run arriba
 arriba \
   -x "$par_bam" \
   -a "$par_genome" \

--- a/src/featurecounts/config.vsh.yaml
+++ b/src/featurecounts/config.vsh.yaml
@@ -28,7 +28,6 @@ functionality:
           alternatives: ["-i"]
           type: file
           multiple: true
-          multiple_sep: ';'
           description: |
             A list of SAM or BAM format files separated by semi-colon (;). They can be either name or location sorted. Location-sorted paired-end reads are automatically sorted by read names.
           required: true
@@ -73,11 +72,10 @@ functionality:
           alternatives: ["-t"]
           type: string
           description: | 
-            Specify feature type(s) in a GTF annotation. If multiple types are provided, they should be separated by ',' with no space in between. 'exon' by default. Rows in the annotation with a matched feature will be extracted and used for read mapping.
+            Specify feature type(s) in a GTF annotation. If multiple types are provided, they should be separated by ';' with no space in between. 'exon' by default. Rows in the annotation with a matched feature will be extracted and used for read mapping.
           example: "exon"
           required: false
           multiple: true
-          multiple_sep: ","
         - name: --attribute_type
           alternatives: ["-g"]
           type: string
@@ -88,10 +86,9 @@ functionality:
         - name: --extra_attributes
           type: string
           description: | 
-            Extract extra attribute types from the provided GTF annotation and include them in the counting output. These attribute types will not be used to group features. If more than one attribute type is provided they should be separated by comma.
+            Extract extra attribute types from the provided GTF annotation and include them in the counting output. These attribute types will not be used to group features. If more than one attribute type is provided they should be separated by semicolon (;).
           required: false
           multiple: true
-          multiple_sep: ","
         - name: --chrom_alias
           alternatives: ["-A"]
           type: file

--- a/src/featurecounts/script.sh
+++ b/src/featurecounts/script.sh
@@ -5,13 +5,20 @@ set -e
 ## VIASH START
 ## VIASH END
 
+# create temporary directory
 tmp_dir=$(mktemp -d -p "$meta_temp_dir" "${meta_functionality_name}_XXXXXX")
 mkdir -p "$tmp_dir/temp"
 
-if [[ $par_detailed_results ]] && [[ ! -d "$par_detailed_results" ]]; then
+# create detailed_results directory if variable is set and directory does not exist
+if [[ ! -z "$par_detailed_results" ]] && [[ ! -d "$par_detailed_results" ]]; then
   mkdir -p "$par_detailed_results"
 fi
 
+# replace comma with semicolon
+par_feature_type=$(echo $par_feature_type | tr ',' ';')
+par_extra_attributes=$(echo $par_extra_attributes | tr ',' ';')
+
+# unset flag variables
 [[ "$par_feature_level" == "false" ]] && unset par_feature_level
 [[ "$par_overlapping" == "false" ]] && unset par_overlapping
 [[ "$par_largest_overlap" == "false" ]] && unset par_largest_overlap


### PR DESCRIPTION
## Description

* Change default `multiple_sep` to `;` (PR #25). This aligns with an upcoming breaking change in
  Viash 0.9.0 in order to avoid issues with the current default separator `:` unintentionally
  splitting up certain file paths.

* Update to Viash 0.8.5 (PR #25).

## Issue ticket number

Closes #xxxx 

<!-- Replace xxxx with the GitHub issue number -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code

- [x] Conforms to the [Contributing guidelines](https://github.com/viash-hub/base/blob/main/CONTRIBUTING.md)

- [x] Proposed changes are described in the [CHANGELOG.md](https://github.com/viash-hub/base/blob/main/CHANGELOG.md)

- [x] I have tested my code with `viash ns test --parallel -q <name or namespace>`

- Check the correct box. Does this PR contain:
  - [x] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [x] Minor changes
  - [ ] Documentation
  - [ ] Bug fixes

<!-- Thank you for your contribution! -->
