### PR TITLE
Fix test and script

### DIFF
--- a/src/gffread/script.sh
+++ b/src/gffread/script.sh
@@ -51,7 +51,7 @@
 [[ "$par_cluster_only" == "false" ]] && unset par_cluster_only
 
 
-gffread \
+$(which gffread) \
     "$par_input" \
     ${par_chr_mapping:+-m "$par_chr_mapping"} \
     ${par_seq_info:+-s "$par_seq_info"} \

--- a/src/gffread/test.sh
+++ b/src/gffread/test.sh
@@ -5,9 +5,9 @@
 
 set -e
 
-test_output_dir="${meta_resources_dir}test_data/test_output"
-test_dir="${meta_resources_dir}test_data"
-expected_output_dir="${meta_resources_dir}test_data/output"
+test_output_dir="${meta_resources_dir}/test_data/test_output"
+test_dir="${meta_resources_dir}/test_data"
+expected_output_dir="${meta_resources_dir}/test_data/output"
 
 mkdir -p "$test_output_dir"
 


### PR DESCRIPTION
I made two small updates to fix two (potential) issues:

1. Point to the `/usr/local/bin/gffread` executable rather than the one in the current directory (if the `$PATH` variable includes `./`).
2. Add a trailing slash to `$meta_resources_dir` in the the test script. This worked in the Docker tests, but not when using the `native` engine [^1].

[^1]: This inconsistency will be fixed in the next version of Viash.
